### PR TITLE
theme.cssのコードブロックの色指定を削除した

### DIFF
--- a/book/theme/theme.css
+++ b/book/theme/theme.css
@@ -64,11 +64,6 @@
   --vs-toc--marker-text-align: end;
 
   /* 
-   * prism
-   */
-  --vs-prism--color-string: #a6e22e;
-
-  /* 
    * page's margins
    */
   --vs-page--margin-top: 20mm;


### PR DESCRIPTION
Vivliostyleの公式テーマのバグ対応のための定義だったが、公式テーマにPRをだし修正された。
https://github.com/vivliostyle/themes/pull/114

が、削除し忘れていたため、削除した。
なお、印刷版（theme-press.css）ではグレースケールに変更する必要があるため、電子版（theme.css）のみ修正している