### PR TITLE
VIVLIOSTYLE_CLI_IMAGE_TAG を最新版の v8.9.1 に更新した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export TEXT_LINT_IMAGE_TAG=latest
 
 ## https://github.com/vivliostyle/vivliostyle-cli/pkgs/container/cli
 VIVLIOSTYLE_CLI_IMAGE_NAME := ghcr.io/vivliostyle/cli
-VIVLIOSTYLE_CLI_IMAGE_TAG := 8.1.2
+VIVLIOSTYLE_CLI_IMAGE_TAG := 8.9.1
 
 ALL_DOCKER_IMAGES := $(TEXT_LINT_IMAGE_NAME) $(VIVLIOSTYLE_CLI_IMAGE_NAME)
 


### PR DESCRIPTION
## やったこと

VIVLIOSTYLE_CLI_IMAGE_TAG を最新版の v8.9.1 に更新した　

## なぜやったか

- Vivliostyle の最新版に追従するため

## 影響範囲

- ページトップに見出しや図版などが存在する場合に、修正前は上部のマージンが存在したが、修正後は存在しなくなった
  - 大きな影響ではないが、ページ内に入る文章の量が増えるので、ページ数削減に寄与するかも

## スクリーンショット

容量が大きかったので Slack にアップロードした
https://yumemi.slack.com/archives/C060P4J16QL/p1710745283170719

