### PR TITLE
PRに対して、PDFを製作＆添付するGitHub Actionsを追加する

### DIFF
--- a/.github/workflows/build-and-attach-pdf-on-pr.yml
+++ b/.github/workflows/build-and-attach-pdf-on-pr.yml
@@ -57,7 +57,7 @@ jobs:
 
       # PR に PDF のアーティファクトリンクを含むコメントを投稿する
       - name: Create PR Comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
fix #81 

PRに対して、PDFを生成する、そのPDFをコメントに添付する GitHub Actions を追加しました

## 背景＆目的

これまでは、PRが作られた際に、それぞれのPDFを手元で生成確認していた。複数のPRが作られた際は対応が大変だった。GitHub Actions で PDF を自動生成する。

このGitHub Actions は、次の問題に対応する

- 記事追加のPRにお願いしていたPDFの添付を不要にする
  - 再修正時の添付漏れも防ぐ
- 利用ライブラリの更新PRに対してCI的な動作として利用する
  - スナップショットテストなど、PDF比較してないので目視で確認する

## 検証

生成されたPDFが [コメント](https://github.com/yumemi/daigirin-template/pull/86#issuecomment-2467052314) に追加されました。なお、[GitHub Actions のストレージ](https://github.com/yumemi/daigirin-template/actions/runs/11770346585) を利用するため、PDFではなくZIPファイルです（一旦手元でダウンロードして解凍するが必要です）。

![スクリーンショット 2024-11-11 10 35 26](https://github.com/user-attachments/assets/e0e41bbe-ea19-4a3e-94e5-ca9a90c71b73)

## レビュー観点

- GitHub Actions の書き方について

## Future Work

- 印刷入稿用のPDFを GitHub Actions で作成する
- 最終稿の電子版と印刷入稿用のPDFを作成するのリリース処理のGitHub Actions で作成する、など
