### PR TITLE
create-or-update-comment のバージョン指定をコミットSHAとバージョン番号に変更した

### DIFF
--- a/.github/workflows/build-and-attach-pdf-on-pr.yml
+++ b/.github/workflows/build-and-attach-pdf-on-pr.yml
@@ -57,7 +57,7 @@ jobs:
 
       # PR に PDF のアーティファクトリンクを含むコメントを投稿する
       - name: Create PR Comment
-        uses: peter-evans/create-or-update-comment@v4.0.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
ref #81 

## 背景

#81 でサードパーティ GitHub Actions の create-or-update-comment をメジャーバージョン指定からコミット番号に設定した。

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
https://zenn.dev/snowcait/articles/53ec922a414dde

マイナーやパッチバージョンで動作変更があっても影響されないようになったが、ライブラリのバージョン管理が新しいコミット番号の [更新 PR](https://github.com/yumemi/daigirin-template/pull/89) を作成した。

- リリース用のコミットではないので、さすがに採用できない
- 都度、マージしない PR が作成されるのは面倒である

## 変更

~バージョン指定をコミット番号から、マイナー・パッチバージョンを含む `v4.0.0` に変更した~

調べたところ、次のように Commit SHAの後に `# バージョン番号` を記述すると、バージョン基準で変更を拾ってくれるそうです。

```
uses: foo/bar@1234 # v1.2.3
```

see: https://blog.chick-p.work/til/fixed-commit-sha-dependabot
see: https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

depandabot は対応済み、renovate は `helpers:pinGitHubActionDigests` を設定すればよいみたいです。ただし、renovate は yarn v4 に対応していないので、~別 PR で depandabot に移行予定です。~ 対応しました。

```
{
  "extends": [
    "helpers:pinGitHubActionDigests"
  ]
}
```


## 検証

PDF作成のコメントが作成されました


