### PR TITLE
bump up ghcr.io/vivliostyle/cli to 8.16.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export TEXT_LINT_IMAGE_TAG=latest
 
 ## https://github.com/vivliostyle/vivliostyle-cli/pkgs/container/cli
 VIVLIOSTYLE_CLI_IMAGE_NAME := ghcr.io/vivliostyle/cli
-VIVLIOSTYLE_CLI_IMAGE_TAG := 8.9.1
+VIVLIOSTYLE_CLI_IMAGE_TAG := 8.16.2
 
 ALL_DOCKER_IMAGES := $(TEXT_LINT_IMAGE_NAME) $(VIVLIOSTYLE_CLI_IMAGE_NAME)
 


### PR DESCRIPTION
## 修正内容

Makefile で指定する vivliostyle のバージョンが最新でなかったため、最新の 8.16.2 に更新した。

## 確認

- `make run` など、この Makefile で指定した vivliostyle を利用する場合に、無事に PDF が作成されました

## 気になること

- バージョン指定だと忘れる場合もあるので、何か vivliostyle の更新をする際は、Makefile も更新する仕組みを作りたい。
  - #103
- Makefile で番号ではなく、latest でしているのはあり？。この指定でビルドできたが、次の latest が来た時にちゃんと解決してくれるかは不明。

```diff
VIVLIOSTYLE_CLI_IMAGE_NAME := ghcr.io/vivliostyle/cli
- VIVLIOSTYLE_CLI_IMAGE_TAG := 8.16.2
+ VIVLIOSTYLE_CLI_IMAGE_TAG := latest
```