### PR TITLE
標準テーマを 1.0.1 に固定して、大技林テーマの 2.0.0 未対応問題の一時回避する

### DIFF
--- a/book/vivliostyle.config.js
+++ b/book/vivliostyle.config.js
@@ -6,8 +6,8 @@ module.exports = {
   theme: [
     '@vivliostyle/theme-base@1.0.1',      // 大技林テーマが 2.0.0 に対応したら削除してください。
     '@vivliostyle/theme-techbook@1.0.1',  // 大技林テーマが 2.0.0 に対応したら削除してください。
-    'vivliostyle-theme-macneko-techbook',
-    '@mitsuharu/vivliostyle-theme-noto-sans-jp',
+    'vivliostyle-theme-macneko-techbook@0.2.0',
+    '@mitsuharu/vivliostyle-theme-noto-sans-jp@0.1.4',
     'theme/theme-custom',
   ],
   entry: [


### PR DESCRIPTION
see #116 

## 背景

- vivliostyleの標準テーマが先日2.0.0に更新された
- 大技林テーマは 1.0.1 で作られており、2.0.0 だと意図しない表示がされる

追記

- 利用するテーマ内で標準テーマ `1.0.1`, `>=1.0.0` のバージョンで利用すると、期待されない `2.0.0` がダウンロードされた
- 標準テーマを `1.0.1` に指定する必要がある

## やったこと

- vivliostyle.config.js で 1.0.1 を指定する

注意点

大技林テーマは latest を指定している。一般的なプロジェクトだと 1.0.1 と latest の２バージョンが混在して、latest が参照されそうだが、viviliosyle はそうではなかった。

## 確認

- [x] PDFが従来通りのレイアウトで表示される
  - ローカルで確認する際は作業ディレクトリの`.vivliostyle` を削除して確認してください


