### PR TITLE
VS Code の textlint 拡張を新しいものに移行する

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "ms-vscode-remote.remote-containers",
     "streetsidesoftware.code-spell-checker",
-    "taichi.vscode-textlint",
+    "3w36zj6.textlint",
     "esbenp.prettier-vscode"
   ],
 }


### PR DESCRIPTION
resolve: #160 
