### PR TITLE
Fix docker-compose build

### DIFF
--- a/DockerfileForDockerCompose
+++ b/DockerfileForDockerCompose
@@ -2,4 +2,4 @@ FROM node:22-alpine
 WORKDIR /workspaces/daigirin-template
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN corepack enable yarn && yarn install --frozen-lockfile && yarn cache clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - .:/workspaces/daigirin-template
       - /workspaces/daigirin-template/node_modules
     working_dir: /workspaces/daigirin-template
-    command: yarn lint
+    command: corepack enable yarn && yarn lint


### PR DESCRIPTION
`make lint`したときにdocker-composeのbuildで失敗しました。
buildできるようにした修正を送ります

```
 => ERROR [lint 4/4] RUN yarn install --frozen-lockfile && yarn   0.6s
------
 > [lint 4/4] RUN yarn install --frozen-lockfile && yarn cache clean:
0.546 error This project's package.json defines "packageManager": "yarn@4.6.0". However the current global version of Yarn is 1.22.22.
0.546 
0.546 Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
0.546 Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
------
```

これで`make lint`が流れると思ったのですが、`command: yarn lint`で落ちています。
ビルドできるように少し進捗したのでプルリクエストを送ってしまいますが、実行できない点は続報がありましたら更新します -> 更新しました

```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...
```