### PR TITLE
Vivliostyleテーマの依存関係更新とマークアップ構造の改善

### DIFF
--- a/book/manuscripts/sample_chapter.md
+++ b/book/manuscripts/sample_chapter.md
@@ -3,7 +3,7 @@ class: content
 ---
 
 <div class="doc-header">
-  <h1>サンプルチャプターのタイトル</h1>
+  <div class="doc-title">サンプルチャプターのタイトル</div>
   <div class="doc-author">サンプルチャプターの著者</div>
 </div>
 

--- a/book/vivliostyle.config.js
+++ b/book/vivliostyle.config.js
@@ -4,9 +4,7 @@ module.exports = {
   language: 'ja',
   size: 'A5',
   theme: [
-    '@vivliostyle/theme-base@1.0.1', // 大技林テーマが 2.0.0 に対応したら削除してください。
-    '@vivliostyle/theme-techbook@1.0.1', // 大技林テーマが 2.0.0 に対応したら削除してください。
-    'vivliostyle-theme-macneko-techbook@0.2.0',
+    'vivliostyle-theme-macneko-techbook@0.4.0',
     '@mitsuharu/vivliostyle-theme-noto-sans-jp@0.1.4',
     'theme/theme-custom',
   ],


### PR DESCRIPTION

## 変更内容

- vivliostyle-theme-macneko-techbookを0.4.0にアップデート
- 不要なテーマの依存関係を削除（@vivliostyle/theme-base, @vivliostyle/theme-techbook）
- チャプタータイトルのマークアップ構造を改善（h1 → div.doc-title）

## 変更理由

- テーマの依存関係を最新化し、メンテナンス性を向上
- 重複する基本テーマを整理し、設定をシンプル化
- マークアップ構造をテーマの仕様に合わせて最適化

## 技術的な詳細

- vivliostyle-theme-macneko-techbook v0.4.0の採用により、基本テーマ（theme-base, theme-techbook）が不要になったため削除
- ドキュメントヘッダーのマークアップを`div.doc-title`に変更し、新しいテーマの仕様に準拠

## 確認項目

- [x] PDFのビルドが正常に完了すること
- [x] チャプタータイトルが正しく表示されること
- [x] ドキュメント全体のスタイルが崩れていないこと